### PR TITLE
PRODENG-2744 Remove sudo -n -l command from sudo detection logic

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -302,7 +302,9 @@ func (c *Connection) configureSudo() {
 		if c.Exec(`doas -n -- "${SHELL-sh}" -c true`) == nil {
 			// user has passwordless doas
 			c.sudofunc = sudoDoas
+			return
 		}
+		c.sudofunc = sudoSudo
 		return
 	}
 


### PR DESCRIPTION
- sudo -n -l command is not a reliable command for this usecase since it is not allowed without password in some systems